### PR TITLE
Fix urls.py

### DIFF
--- a/xerror/xerror/urls.py
+++ b/xerror/xerror/urls.py
@@ -1,15 +1,14 @@
 
 from django.conf.urls import url, include
 from django.contrib import admin
+from django.conf.urls.static import static
 import settings
 
 urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^', include('parsing.urls')),
-    url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
-                 {'document_root': settings.MEDIA_ROOT}),
 
-]
+] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 
 


### PR DESCRIPTION
According to the document django version >= 1.7 
which is not support the following URL configuration
```
 url(r'^media/(?P<path>.*)$', 'django.views.static.serve',
                  {'document_root': settings.MEDIA_ROOT}),
```
so I fix it to 
`+ static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)` 
at the end of url configuration
and also the require library.
`from django.conf.urls.static import static`
